### PR TITLE
Fixed provide name

### DIFF
--- a/emacs/netlogo-mode.el
+++ b/emacs/netlogo-mode.el
@@ -272,4 +272,4 @@
   (make-local-variable 'comment-start)
   (setq comment-start ";"))
 
-(provide 'netlogo)
+(provide 'netlogo-mode)


### PR DESCRIPTION
I'm honestly a bit uncertain if there is some kind of naming convention and how provide/require should be used. However, I could not load the package without this change.